### PR TITLE
Allow passing an empty message string

### DIFF
--- a/qrplatba/spayd.py
+++ b/qrplatba/spayd.py
@@ -112,7 +112,7 @@ class QRPlatbaGenerator:
         return ''
 
     def _format_item_string(self, item, name):
-        if item is not None:
+        if item:
             return "{name}:{value}*".format(name=name, value=item)
         return ''
 


### PR DESCRIPTION
The following function call generated an incorrect QR format that at least Moneta bank could not load:
`QRPlatbaGenerator('123456/0600', 123, x_vs=456, message='')`